### PR TITLE
fix: typo

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -12,4 +12,4 @@ pre-commit:
 commit-msg:
   commands:
     "lint commit message":
-      run: pnpm commitlint --edit ${1} --config .commitlintrc
+      run: pnpm commitlint --edit {1} --config .commitlintrc


### PR DESCRIPTION
## Description

Fix typo in `lefthook.yaml`