### PR TITLE
Update `lefthook.yaml`

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,7 +3,11 @@ pre-commit:
   commands:
     1_format:
       glob: "*.{js,jsx,ts,tsx,mjs,mts,yaml,json,html,css}"
-      run: pnpm prettier {staged_files} --write
+      run: |
+        pnpm prettier {staged_files} --write \
+        | grep -v "(unchanged)" \
+        | awk '{print $1}' \
+        | xargs git add
 
     2_lint:
       glob: "*.{js,jsx,ts,tsx,mjs,mts}"


### PR DESCRIPTION
## Description

In the previous `lefthook.yaml` configuration, files formatted by Prettier were not being staged before running ESLint for linting. With this PR, the changes ensure that the diffs of files formatted within the pre-commit hook are additionally staged.